### PR TITLE
Resolving __init__.py conflict between this library and replit-py

### DIFF
--- a/src/replit/__init__.py
+++ b/src/replit/__init__.py
@@ -1,1 +1,0 @@
-"""Root interface for replit packages."""

--- a/src/replit/object_storage/client.py
+++ b/src/replit/object_storage/client.py
@@ -10,7 +10,6 @@ import requests
 from google.auth import identity_pool
 from google.cloud import storage
 from google.cloud.exceptions import NotFound
-
 from replit.object_storage._config import REPLIT_ADC, REPLIT_DEFAULT_BUCKET_URL
 from replit.object_storage.errors import (
   DefaultBucketError,


### PR DESCRIPTION
Resolves #13 

## After `poetry install`:
```
$ poetry run python
Python 3.11.6 (main, Oct  2 2023, 13:45:54) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import replit
>>> dir(replit)
['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__']
>>> from replit import object_storage
>>>
```

## Install `replit-py`:
```
$ poetry run pip install replit
Collecting replit
  Downloading replit-4.0.0-py3-none-any.whl.metadata (2.5 kB)
...
Installing collected packages: Werkzeug, pycryptodomex, pycparser, multidict, itsdangerous, iso8601, frozenlist, blinker, attrs, yarl, Flask, cffi, aiosignal, cryptography, argon2-cffi-bindings, aiohttp, argon2-cffi, aiohttp-retry, pyseto, replit
Successfully installed Flask-3.0.3 Werkzeug-3.0.3 aiohttp-3.9.5 aiohttp-retry-2.8.3 aiosignal-1.3.1 argon2-cffi-23.1.0 argon2-cffi-bindings-21.2.0 attrs-23.2.0 blinker-1.8.2 cffi-1.16.0 cryptography-42.0.8 frozenlist-1.4.1 iso8601-2.1.0 itsdangerous-2.2.0 multidict-6.0.5 pycparser-2.22 pycryptodomex-3.20.0 pyseto-1.7.8 replit-4.0.0 yarl-1.9.4
```

## Observe that members are there
```
$ poetry run python
Python 3.11.6 (main, Oct  2 2023, 13:45:54) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import replit
>>> dir(replit)
['Any', 'AsyncDatabase', 'Database', 'ReplInfo', '__builtins__', '__cached__', '__doc__', '__file__', '__getattr__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'clear', 'database', 'info', 'make_database_proxy_blueprint', 'start_database_proxy', 'web']
>>>
```

## Reinstall ourselves to overwrite `__init__.py`
```
$ poetry run pip install --force .
```

## Observe that members are still there
```
$ poetry run python
Python 3.11.6 (main, Oct  2 2023, 13:45:54) [Clang 16.0.6 ] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import replit
>>> dir(replit)
['Any', 'AsyncDatabase', 'Database', 'ReplInfo', '__builtins__', '__cached__', '__doc__', '__file__', '__getattr__', '__loader__', '__name__', '__package__', '__path__', '__spec__', 'clear', 'database', 'info', 'make_database_proxy_blueprint', 'start_database_proxy', 'web']
>>>
```