### PR TITLE
chore/publish attempt #3

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,11 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'What version to use for the release'
+        required: true
 
 jobs:
   deploy:
@@ -27,7 +32,10 @@ jobs:
 
     - name: Set release version
       run: |
-        tag="${GITHUB_REF_NAME}"
+        tag="${{ github.event.inputs.version }}"
+        if [ -z "$tag" ]; then
+          tag="${GITHUB_REF_NAME}"
+        fi
         version="${tag#v}"  # Strip leading v
 
         # Bump poetry tag

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,6 +35,7 @@ jobs:
 
     - name: Build and publish
       run: |
+        poetry build
         TWINE_USERNAME=__token__ \
         TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" \
-        make release
+        poetry run twine upload dist/*

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,10 +1,11 @@
 name: Release Drafter
 
 on:
+  workflow_dispatch: {}
   push:
     # branches to consider in the event; optional, defaults to all
     branches:
-      - master
+      - main
   # pull_request event is required only for autolabeler
   pull_request:
     # Only following types are handled by the action, but one can default to all as well


### PR DESCRIPTION
Why
===

This project was intended to be developed in a Repl, so tests rely on the sidecar to be present. This is good and useful, but for our purposes we should just bypass that requirement when we are trying to release.

What changed
============

- Replicated the build workflow
- release-drafter seems to have [developed a bug](https://github.com/release-drafter/release-drafter/issues/1290), but what makes it harder to verify is not being able to manually run the workflow.

Test plan
=========

Can we finally release 1.0.1?

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
