### PR TITLE
publish bug: Missing poetry install

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Build and publish
       run: |
+        poetry install
         poetry build
         TWINE_USERNAME=__token__ \
         TWINE_PASSWORD="${{ secrets.PYPI_TOKEN }}" \


### PR DESCRIPTION
Why
===

Without `poetry install`, `poetry run twine` fails.

What changed
============

Run `poetry install`

Test plan
=========

https://github.com/replit/replit-object-storage-python v1.0.1 has been released, this should be the last change required.

Rollout
=======

_Describe any procedures or requirements needed to roll this out safely (or check the box below)_

- [x] This is fully backward and forward compatible
