### PR TITLE
ci: remove pull_request_target trigger from release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,9 +10,6 @@ on:
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Why
===

The recent [TanStack NPM supply-chain compromise](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) was facilitated by a `pull_request_target` workflow. Per Replit security policy, we're removing `pull_request_target` triggers from all Replit-owned public repos as a precaution, even where the current use looks safe, to eliminate exposure to that attack pattern.

Discussion: [Slack thread](https://replit.slack.com/archives/C03FS477T17/p1778588219046429).

What changed
============

Removed the `pull_request_target` trigger block from `.github/workflows/release-drafter.yml`. The workflow still runs on:

- `workflow_dispatch` (manual)
- `push` to `main` — release notes continue to be drafted on merge
- `pull_request` from branches in the same repo — autolabeler still runs here

Tradeoff: the autolabeler will no longer run on PRs opened from forks. That's an acceptable loss given the security benefit, and the rest of the release-drafter flow (drafting release notes on push to `main`) is unaffected.

Test plan
=========

- Diff is a clean removal of the `pull_request_target:` block; no other lines change.
- `yq`/manual YAML inspection confirms the remaining `on:` triggers (`workflow_dispatch`, `push`, `pull_request`) still parse correctly.
- Behavioral verification will happen on the next merge to `main` (release notes still draft) and the next intra-repo PR (autolabeler still fires).

Rollout
=======

- [x] This is fully backward and forward compatible

Workflow-only change with no runtime impact on the published package.

Revertibility
=============

Safe to revert. This is a workflow-only change; reverting restores the prior trigger configuration with no data or state implications.

---

~ written by Zerg :space_invader: ([hungry-medic-9d57](https://zerg.zergrush.dev/chat?id=hungry-medic-9d57))
